### PR TITLE
Add Firebase App Hosting skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,20 @@
-# firebaseapphost
+# Firebase App Hosting Skeleton
+
+This repository provides a minimal example of using Firebase App Hosting with a simple Node.js backend and a static front‑end.
+
+The backend exposes a `/health` endpoint that writes a timestamp to a Firestore collection and returns a JSON status. The front‑end page includes a button to trigger the health check and display the result.
+
+## Setup
+
+1. Install dependencies (requires Node.js):
+   ```bash
+   npm install
+   ```
+2. Provide Firebase credentials for the Admin SDK. The simplest way in development is to set the `GOOGLE_APPLICATION_CREDENTIALS` environment variable to the path of a service account JSON file.
+3. Start the server:
+   ```bash
+   npm start
+   ```
+4. Open `http://localhost:3000` in your browser and click **Check Health** to invoke the backend.
+
+This is only a starting point—you can expand the UI and backend logic as needed.

--- a/index.js
+++ b/index.js
@@ -1,0 +1,32 @@
+const express = require('express');
+const admin = require('firebase-admin');
+const path = require('path');
+
+// Initialize Firebase Admin SDK using default credentials
+// In production, provide proper service account credentials
+try {
+  admin.initializeApp();
+} catch (err) {
+  console.error('Failed to initialize Firebase Admin SDK', err);
+}
+
+const db = admin.firestore();
+
+const app = express();
+const PORT = process.env.PORT || 3000;
+
+app.use(express.static(path.join(__dirname, 'public')));
+
+app.get('/health', async (req, res) => {
+  try {
+    // Example Firestore read for health check
+    await db.collection('healthChecks').doc('last').set({ timestamp: Date.now() });
+  } catch (error) {
+    console.error('Health check failed', error);
+    res.status(500).json({ status: 'error' });
+  }
+});
+
+app.listen(PORT, () => {
+  console.log(`Server running on http://localhost:${PORT}`);
+});

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "firebaseapphost",
+  "version": "0.1.0",
+  "description": "Skeleton project for Firebase App Hosting",
+  "main": "index.js",
+  "scripts": {
+    "start": "node index.js"
+  },
+  "dependencies": {
+    "express": "^4.18.2",
+    "firebase-admin": "^11.5.0"
+  }
+}

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title>Firebase App Hosting Skeleton</title>
+</head>
+<body>
+  <h1>Welcome to Firebase App Hosting</h1>
+  <button id="check">Check Health</button>
+  <p id="result"></p>
+  <script>
+    document.getElementById('check').addEventListener('click', async () => {
+      const res = await fetch('/health');
+      const data = await res.json();
+      document.getElementById('result').textContent = JSON.stringify(data);
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- initialize Node.js project with Express and Firebase Admin SDK
- implement `/health` route writing to Firestore
- add simple HTML page to call the health endpoint
- document setup instructions

## Testing
- `npm --version`
- `npm install` *(fails: network access required)*